### PR TITLE
Resolve reactor dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ Using the Unleash Maven Plugin brings some significant advantages over the stand
 4. **Being extendable by nature**
   * Since the Unleash Maven Plugin is built on top of the [Maven CDI Plugin Utils](https://github.com/shillner/maven-cdi-plugin-utils) library it is extendable by nature. This means that concepts such as dependency injection, processing steps and workflow-based orchestration of the steps enable you to implement your own processing steps or take pre-implemented steps of other projects and add them as dependencies to your plugin configuration. Once these steps are available on classpath you can embed them into the processing workflow to extend or redefine its functionality.
 5. **Reusable SCM provider implementations**
-  * The dependency injection approach and the implementation of the SCM provider registry of the Unleash Maven Plugin allows SCM providers to be implemented, released and deliverd as independent units.
+  * The dependency injection approach and the implementation of the SCM provider registry of the Unleash Maven Plugin allows SCM providers to be implemented, released and delivered as independent units.
   * Simply add the required scm provider to the plugin dependencies to lay it onto the classpath and it will be found.
   * SCM provider implementations can also be used in other contexts besides this plugin and this is already done. 
 
 
 What Is It Built On?
 --------------------
-The Unleash Maven Plugin is built on the new library Maven CDI Plugin Utils which provides some concepts that increases the possibilities of implementing Maven plugins enormously. Is gives you f.i. CDI-based dependency injection and a workflow-based processing model and pushes reusability, extendability and customizablity to a higher level.
+The Unleash Maven Plugin is built on the new library Maven CDI Plugin Utils which provides some concepts that increases the possibilities of implementing Maven plugins enormously. Is gives you f.i. CDI-based dependency injection and a workflow-based processing model and pushes reusability, extendability and customizability to a higher level.
 
 More about the library can be found here: [Maven CDI Plugin Utils](https://github.com/shillner/maven-cdi-plugin-utils)
 
@@ -50,7 +50,7 @@ CI Server Integration
 ---------------------
 Releases should be built by Continuous Integration Servers only. This is much safer than building them on a local machine since your personal setup and local repository could influence the release build in an unwanted  way.
 
-On any CI server you have the option to create a sepatate "release job" that sets all necessary optional and calls the  unleash goals manually. When you build this job a new release will be built. Althouth this is possible and the simplest solution it is quite uncomfortable and error prone since you will have to maintain two different build jobs for the same project. To face this problem there is a plugin for the [Jenkins CI server](https://jenkins.io/) which lets you trigger a release build for an existing Maven job. It is able to store plugin settings globally and locally to make release building as easy as clicking a link.
+On any CI server you have the option to create a separate "release job" that sets all necessary optional and calls the  unleash goals manually. When you build this job a new release will be built. Although this is possible and the simplest solution it is quite uncomfortable and error prone since you will have to maintain two different build jobs for the same project. To face this problem there is a plugin for the [Jenkins CI server](https://jenkins.io/) which lets you trigger a release build for an existing Maven job. It is able to store plugin settings globally and locally to make release building as easy as clicking a link.
 
 The Jenkins plugin can be found here: [Unleash Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Unleash+Plugin)
 Simply install it using the Jenkins Plugin manager and you are all set ;)

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -32,6 +32,7 @@
     <version.mockito-all>1.10.19</version.mockito-all>
     <version.plexus-interactivity-api>1.0-alpha-6</version.plexus-interactivity-api>
     <version.tycho-versions-plugin>0.25.0</version.tycho-versions-plugin>
+    <version.versions-maven-plugin>2.4</version.versions-maven-plugin>
     <version.weld-se>2.3.3.Final</version.weld-se>
   </properties>
 
@@ -172,6 +173,11 @@
       <groupId>org.jboss.weld.se</groupId>
       <artifactId>weld-se</artifactId>
       <version>${version.weld-se}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.mojo</groupId>
+      <artifactId>versions-maven-plugin</artifactId>
+      <version>${version.versions-maven-plugin}</version>
     </dependency>
   </dependencies>
 

--- a/plugin/src/main/java/com/itemis/maven/plugins/unleash/UnleashMojo.java
+++ b/plugin/src/main/java/com/itemis/maven/plugins/unleash/UnleashMojo.java
@@ -147,6 +147,11 @@ public class UnleashMojo extends AbstractCDIMojo {
   @Named("tagNamePattern")
   private String tagNamePattern;
 
+  @Parameter(defaultValue = "true", property = "unleash.updateReactorDependencyVersion", required = true)
+  @MojoProduces
+  @Named("updateReactorDependencyVersion")
+  private boolean updateReactorDependencyVersion;
+
   //////////////////////////// optional
   @Parameter(property = "unleash.developmentVersion", required = false)
   @MojoProduces

--- a/plugin/src/main/java/com/itemis/maven/plugins/unleash/steps/actions/AbstractVersionsStep.java
+++ b/plugin/src/main/java/com/itemis/maven/plugins/unleash/steps/actions/AbstractVersionsStep.java
@@ -1,0 +1,144 @@
+package com.itemis.maven.plugins.unleash.steps.actions;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.itemis.maven.aether.ArtifactCoordinates;
+import com.itemis.maven.plugins.cdi.CDIMojoProcessingStep;
+import com.itemis.maven.plugins.cdi.logging.Logger;
+import com.itemis.maven.plugins.unleash.ReleaseMetadata;
+import com.itemis.maven.plugins.unleash.ReleasePhase;
+import com.itemis.maven.plugins.unleash.util.PomUtil;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Profile;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.mojo.versions.api.PomHelper;
+import org.w3c.dom.Document;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * An abstract step for version upgrades in POMs.
+ *
+ * @author <a href="mailto:tangtheone@gmail.com">Pei-Tang Huang</a>
+ * @since 2.6.1
+ */
+public abstract class AbstractVersionsStep implements CDIMojoProcessingStep {
+  @Inject
+  protected Logger log;
+
+  @Inject
+  protected ReleaseMetadata metadata;
+
+  @Inject
+  @Named("reactorProjects")
+  protected List<MavenProject> reactorProjects;
+
+  protected Map<ArtifactCoordinates, Document> cachedPOMs;
+
+  @Inject
+  @Named("updateReactorDependencyVersion")
+  protected boolean updateReactorDependencyVersion;
+
+  // Raw models is only used for dependency version updating currently.
+  // This may cause inconsistencies between reactorProjects and updated POMs.
+  // However, I have no confidence in spread it out of this step.
+  // TODO make the whole plugin work on raw models? (after having integration tests...)
+  private LoadingCache<MavenProject, Model> rawModels = CacheBuilder.newBuilder().build(
+          new CacheLoader<MavenProject, Model>() {
+            @Override
+            public Model load(MavenProject project) throws Exception {
+              return PomHelper.getRawModel(project);
+            }
+          });
+
+  protected void setProjectReactorDependenciesVersion(MavenProject project, Document document) {
+    final String dependenciesPath = "/";
+    List<Dependency> dependencies = rawModels.getUnchecked(project).getDependencies();
+    for (Dependency dependency : dependencies) {
+      trySetDependencyVersionFromReactorProjects(project, document, dependenciesPath, dependency);
+    }
+  }
+
+  protected void setProjectReactorDependencyManagementVersion(MavenProject project, Document document) {
+    DependencyManagement dependencyManagement = rawModels.getUnchecked(project).getDependencyManagement();
+    if (dependencyManagement != null) {
+      String dependenciesPath = "/dependencyManagement";
+      List<Dependency> dependencies = dependencyManagement.getDependencies();
+      for (Dependency dependency : dependencies) {
+        trySetDependencyVersionFromReactorProjects(project, document, dependenciesPath, dependency);
+      }
+    }
+  }
+
+  protected void setProfilesReactorDependenciesVersion(MavenProject project, Document document) {
+    List<Profile> profiles = rawModels.getUnchecked(project).getProfiles();
+    for (Profile profile : profiles) {
+      final String dependenciesPath = "/profiles/profile[id[text()='" + profile.getId() + "']]";
+      List<Dependency> dependencies = profile.getDependencies();
+      for (Dependency dependency : dependencies) {
+        trySetDependencyVersionFromReactorProjects(project, document, dependenciesPath, dependency);
+      }
+    }
+  }
+
+  protected void setProfilesReactorDependencyManagementVersion(MavenProject project, Document document) {
+    List<Profile> profiles = rawModels.getUnchecked(project).getProfiles();
+    for (Profile profile : profiles) {
+      final String dependenciesPath = "/profiles/profile[id[text()='" + profile.getId() + "']]/dependencyManagement";
+      DependencyManagement dependencyManagement = profile.getDependencyManagement();
+      if (dependencyManagement != null) {
+        List<Dependency> dependencies = dependencyManagement.getDependencies();
+        for (Dependency dependency : dependencies) {
+          trySetDependencyVersionFromReactorProjects(project, document, dependenciesPath, dependency);
+        }
+      }
+    }
+  }
+
+  protected abstract ReleasePhase previousReleasePhase();
+
+  protected abstract ReleasePhase currentReleasePhase();
+
+  private void trySetDependencyVersionFromReactorProjects(MavenProject project, Document document, String dependenciesPath, Dependency dependency) {
+    for (MavenProject reactorProject : reactorProjects) {
+      if (isReactorDependency(reactorProject, dependency)) {
+        Map<ReleasePhase, ArtifactCoordinates> coordinatesByPhase = this.metadata
+                .getArtifactCoordinatesByPhase(dependency.getGroupId(), dependency.getArtifactId());
+        ArtifactCoordinates oldCoordinates = coordinatesByPhase.get(previousReleasePhase());
+        ArtifactCoordinates newCoordinates = coordinatesByPhase.get(currentReleasePhase());
+
+        if (newCoordinates == null || oldCoordinates == null) {
+          // the dependency is not part of the reactor projects since no release version had been calculated for it
+
+        } else if (dependency.getVersion() == null) {
+          // version was managed somewhere
+
+        } else if (Objects.equals(dependency.getVersion(), oldCoordinates.getVersion())) {
+          this.log.debug("\tUpdate of dependency '" + dependency.getGroupId() + ":"
+                  + dependency.getArtifactId() + "' version in '" + dependenciesPath + "' of module '"
+                  + project.getGroupId() + ":" + project.getArtifact() + "' [" + oldCoordinates.getVersion() + " => "
+                  + newCoordinates.getVersion() + "]");
+          PomUtil.setDependencyVersion(dependency, document, dependenciesPath, newCoordinates.getVersion());
+        }
+      }
+    }
+  }
+
+  private boolean isReactorDependency(MavenProject project, Dependency dependency) {
+    String groupId = dependency.getGroupId();
+    String artifactId = dependency.getArtifactId();
+
+    Model model = rawModels.getUnchecked(project);
+    String reactorGroupId = model.getGroupId() != null ? model.getGroupId() : model.getParent().getGroupId();
+    String reactorArtifactId = model.getArtifactId();
+
+    return Objects.equals(groupId, reactorGroupId) && Objects.equals(artifactId, reactorArtifactId);
+  }
+}

--- a/plugin/src/main/java/com/itemis/maven/plugins/unleash/steps/actions/SetNextDevVersion.java
+++ b/plugin/src/main/java/com/itemis/maven/plugins/unleash/steps/actions/SetNextDevVersion.java
@@ -65,6 +65,12 @@ public class SetNextDevVersion extends AbstractVersionsStep {
         Document document = PomUtil.parsePOM(project);
         setProjectVersion(project, document);
         setParentVersion(project, document);
+        if (updateReactorDependencyVersion) {
+          setProjectReactorDependenciesVersion(project, document);
+          setProjectReactorDependencyManagementVersion(project, document);
+          setProfilesReactorDependenciesVersion(project, document);
+          setProfilesReactorDependencyManagementVersion(project, document);
+        }
         this.util.revertScmSettings(project, document);
         PomUtil.writePOM(document, project);
       } catch (Throwable t) {

--- a/plugin/src/main/java/com/itemis/maven/plugins/unleash/steps/actions/SetReleaseVersions.java
+++ b/plugin/src/main/java/com/itemis/maven/plugins/unleash/steps/actions/SetReleaseVersions.java
@@ -37,46 +37,10 @@ public class SetReleaseVersions extends AbstractVersionsStep {
       this.cachedPOMs.put(ProjectToCoordinates.EMPTY_VERSION.apply(project), PomUtil.parsePOM(project));
 
       try {
-        Document document = PomUtil.parsePOM(project);
-        setProjectVersion(project, document);
-        setParentVersion(project, document);
-        if (updateReactorDependencyVersion) {
-          setProjectReactorDependenciesVersion(project, document);
-          setProjectReactorDependencyManagementVersion(project, document);
-          setProfilesReactorDependenciesVersion(project, document);
-          setProfilesReactorDependencyManagementVersion(project, document);
-        }
+        Document document = loadAndProcess(project);
         PomUtil.writePOM(document, project);
       } catch (Throwable t) {
         throw new MojoFailureException("Could not update versions for release.", t);
-      }
-    }
-  }
-
-  private void setProjectVersion(MavenProject project, Document document) {
-    Map<ReleasePhase, ArtifactCoordinates> coordinatesByPhase = this.metadata
-        .getArtifactCoordinatesByPhase(project.getGroupId(), project.getArtifactId());
-    String oldVersion = coordinatesByPhase.get(previousReleasePhase()).getVersion();
-    String newVersion = coordinatesByPhase.get(currentReleasePhase()).getVersion();
-    this.log.debug("\tUpdate of module version '" + project.getGroupId() + ":" + project.getArtifact() + "' ["
-        + oldVersion + " => " + newVersion + "]");
-    PomUtil.setProjectVersion(project.getModel(), document, newVersion);
-  }
-
-  private void setParentVersion(MavenProject project, Document document) {
-    Parent parent = project.getModel().getParent();
-    if (parent != null) {
-      Map<ReleasePhase, ArtifactCoordinates> coordinatesByPhase = this.metadata
-          .getArtifactCoordinatesByPhase(parent.getGroupId(), parent.getArtifactId());
-      ArtifactCoordinates oldCoordinates = coordinatesByPhase.get(previousReleasePhase());
-      ArtifactCoordinates newCoordinates = coordinatesByPhase.get(currentReleasePhase());
-
-      // null indicates that the parent is not part of the reactor projects since no release version had been calculated
-      // for it
-      if (newCoordinates != null) {
-        this.log.debug("\tUpdate of parent version of module '" + project.getGroupId() + ":" + project.getArtifact()
-            + "' [" + oldCoordinates.getVersion() + " => " + newCoordinates.getVersion() + "]");
-        PomUtil.setParentVersion(project.getModel(), document, newCoordinates.getVersion());
       }
     }
   }

--- a/plugin/src/main/java/com/itemis/maven/plugins/unleash/steps/actions/SetReleaseVersions.java
+++ b/plugin/src/main/java/com/itemis/maven/plugins/unleash/steps/actions/SetReleaseVersions.java
@@ -1,34 +1,18 @@
 package com.itemis.maven.plugins.unleash.steps.actions;
 
-import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
-import javax.inject.Inject;
-import javax.inject.Named;
-
-import org.apache.maven.model.Dependency;
-import org.apache.maven.model.DependencyManagement;
-import org.apache.maven.model.Model;
 import org.apache.maven.model.Parent;
-import org.apache.maven.model.Profile;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.mojo.versions.api.PomHelper;
 import org.w3c.dom.Document;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Maps;
 import com.itemis.maven.aether.ArtifactCoordinates;
-import com.itemis.maven.plugins.cdi.CDIMojoProcessingStep;
 import com.itemis.maven.plugins.cdi.ExecutionContext;
 import com.itemis.maven.plugins.cdi.annotations.ProcessingStep;
 import com.itemis.maven.plugins.cdi.annotations.RollbackOnError;
-import com.itemis.maven.plugins.cdi.logging.Logger;
-import com.itemis.maven.plugins.unleash.ReleaseMetadata;
 import com.itemis.maven.plugins.unleash.ReleasePhase;
 import com.itemis.maven.plugins.unleash.util.PomUtil;
 import com.itemis.maven.plugins.unleash.util.functions.ProjectToCoordinates;
@@ -42,30 +26,7 @@ import com.itemis.maven.plugins.unleash.util.functions.ProjectToString;
  * @since 1.0.0
  */
 @ProcessingStep(id = "setReleaseVersions", description = "Updates the POMs of all project modules with their release versions calculated previously.", requiresOnline = false)
-public class SetReleaseVersions implements CDIMojoProcessingStep {
-  @Inject
-  private Logger log;
-  @Inject
-  private ReleaseMetadata metadata;
-  @Inject
-  @Named("reactorProjects")
-  private List<MavenProject> reactorProjects;
-  private Map<ArtifactCoordinates, Document> cachedPOMs;
-  @Inject
-  @Named("updateReactorDependencyVersion")
-  private boolean updateReactorDependencyVersion;
-
-  // Raw models is only used for dependency version updating currently.
-  // This may cause inconsistencies between reactorProjects and updated POMs.
-  // However, I have no confidence in spread it out of this step.
-  // TODO make the whole plugin work on raw models? (after having integration tests...)
-  private LoadingCache<MavenProject, Model> rawModels = CacheBuilder.newBuilder().build(
-          new CacheLoader<MavenProject, Model>() {
-            @Override
-            public Model load(MavenProject project) throws Exception {
-              return PomHelper.getRawModel(project);
-            }
-          });
+public class SetReleaseVersions extends AbstractVersionsStep {
 
   @Override
   public void execute(ExecutionContext context) throws MojoExecutionException, MojoFailureException {
@@ -95,8 +56,8 @@ public class SetReleaseVersions implements CDIMojoProcessingStep {
   private void setProjectVersion(MavenProject project, Document document) {
     Map<ReleasePhase, ArtifactCoordinates> coordinatesByPhase = this.metadata
         .getArtifactCoordinatesByPhase(project.getGroupId(), project.getArtifactId());
-    String oldVersion = coordinatesByPhase.get(ReleasePhase.PRE_RELEASE).getVersion();
-    String newVersion = coordinatesByPhase.get(ReleasePhase.RELEASE).getVersion();
+    String oldVersion = coordinatesByPhase.get(previousReleasePhase()).getVersion();
+    String newVersion = coordinatesByPhase.get(currentReleasePhase()).getVersion();
     this.log.debug("\tUpdate of module version '" + project.getGroupId() + ":" + project.getArtifact() + "' ["
         + oldVersion + " => " + newVersion + "]");
     PomUtil.setProjectVersion(project.getModel(), document, newVersion);
@@ -107,8 +68,8 @@ public class SetReleaseVersions implements CDIMojoProcessingStep {
     if (parent != null) {
       Map<ReleasePhase, ArtifactCoordinates> coordinatesByPhase = this.metadata
           .getArtifactCoordinatesByPhase(parent.getGroupId(), parent.getArtifactId());
-      ArtifactCoordinates oldCoordinates = coordinatesByPhase.get(ReleasePhase.PRE_RELEASE);
-      ArtifactCoordinates newCoordinates = coordinatesByPhase.get(ReleasePhase.RELEASE);
+      ArtifactCoordinates oldCoordinates = coordinatesByPhase.get(previousReleasePhase());
+      ArtifactCoordinates newCoordinates = coordinatesByPhase.get(currentReleasePhase());
 
       // null indicates that the parent is not part of the reactor projects since no release version had been calculated
       // for it
@@ -120,84 +81,14 @@ public class SetReleaseVersions implements CDIMojoProcessingStep {
     }
   }
 
-  private void setProjectReactorDependenciesVersion(MavenProject project, Document document) {
-    final String dependenciesPath = "/";
-    List<Dependency> dependencies = rawModels.getUnchecked(project).getDependencies();
-    for (Dependency dependency : dependencies) {
-      trySetDependencyVersionFromReactorProjects(project, document, dependenciesPath, dependency);
-    }
+  @Override
+  protected ReleasePhase previousReleasePhase() {
+    return ReleasePhase.PRE_RELEASE;
   }
 
-  private void setProjectReactorDependencyManagementVersion(MavenProject project, Document document) {
-    DependencyManagement dependencyManagement = rawModels.getUnchecked(project).getDependencyManagement();
-    if (dependencyManagement != null) {
-      String dependenciesPath = "/dependencyManagement";
-      List<Dependency> dependencies = dependencyManagement.getDependencies();
-      for (Dependency dependency : dependencies) {
-        trySetDependencyVersionFromReactorProjects(project, document, dependenciesPath, dependency);
-      }
-    }
-  }
-
-  private void setProfilesReactorDependenciesVersion(MavenProject project, Document document) {
-    List<Profile> profiles = rawModels.getUnchecked(project).getProfiles();
-    for (Profile profile : profiles) {
-      final String dependenciesPath = "/profiles/profile[id[text()='" + profile.getId() + "']]";
-      List<Dependency> dependencies = profile.getDependencies();
-      for (Dependency dependency : dependencies) {
-        trySetDependencyVersionFromReactorProjects(project, document, dependenciesPath, dependency);
-      }
-    }
-  }
-
-  private void setProfilesReactorDependencyManagementVersion(MavenProject project, Document document) {
-    List<Profile> profiles = rawModels.getUnchecked(project).getProfiles();
-    for (Profile profile : profiles) {
-      final String dependenciesPath = "/profiles/profile[id[text()='" + profile.getId() + "']]/dependencyManagement";
-      DependencyManagement dependencyManagement = profile.getDependencyManagement();
-      if (dependencyManagement != null) {
-        List<Dependency> dependencies = dependencyManagement.getDependencies();
-        for (Dependency dependency : dependencies) {
-          trySetDependencyVersionFromReactorProjects(project, document, dependenciesPath, dependency);
-        }
-      }
-    }
-  }
-
-  private void trySetDependencyVersionFromReactorProjects(MavenProject project, Document document, String dependenciesPath, Dependency dependency) {
-    for (MavenProject reactorProject : reactorProjects) {
-      if (isReactorDependency(reactorProject, dependency)) {
-        Map<ReleasePhase, ArtifactCoordinates> coordinatesByPhase = this.metadata
-                .getArtifactCoordinatesByPhase(dependency.getGroupId(), dependency.getArtifactId());
-        ArtifactCoordinates oldCoordinates = coordinatesByPhase.get(ReleasePhase.PRE_RELEASE);
-        ArtifactCoordinates newCoordinates = coordinatesByPhase.get(ReleasePhase.RELEASE);
-
-        if (newCoordinates == null || oldCoordinates == null) {
-          // the dependency is not part of the reactor projects since no release version had been calculated for it
-
-        } else if (dependency.getVersion() == null) {
-          // version was managed somewhere
-
-        } else if (Objects.equals(dependency.getVersion(), oldCoordinates.getVersion())) {
-          this.log.debug("\tUpdate of dependency '" + dependency.getGroupId() + ":"
-                  + dependency.getArtifactId() + "' version in '" + dependenciesPath + "' of module '"
-                  + project.getGroupId() + ":" + project.getArtifact() + "' [" + oldCoordinates.getVersion() + " => "
-                  + newCoordinates.getVersion() + "]");
-          PomUtil.setDependencyVersion(dependency, document, dependenciesPath, newCoordinates.getVersion());
-        }
-      }
-    }
-  }
-
-  private boolean isReactorDependency(MavenProject project, Dependency dependency) {
-    String groupId = dependency.getGroupId();
-    String artifactId = dependency.getArtifactId();
-
-    Model model = rawModels.getUnchecked(project);
-    String reactorGroupId = model.getGroupId() != null ? model.getGroupId() : model.getParent().getGroupId();
-    String reactorArtifactId = model.getArtifactId();
-
-    return Objects.equals(groupId, reactorGroupId) && Objects.equals(artifactId, reactorArtifactId);
+  @Override
+  protected ReleasePhase currentReleasePhase() {
+    return ReleasePhase.RELEASE;
   }
 
   @RollbackOnError

--- a/plugin/src/main/java/com/itemis/maven/plugins/unleash/steps/actions/SetReleaseVersions.java
+++ b/plugin/src/main/java/com/itemis/maven/plugins/unleash/steps/actions/SetReleaseVersions.java
@@ -65,10 +65,10 @@ public class SetReleaseVersions implements CDIMojoProcessingStep {
   private void setProjectVersion(MavenProject project, Document document) {
     Map<ReleasePhase, ArtifactCoordinates> coordinatesByPhase = this.metadata
         .getArtifactCoordinatesByPhase(project.getGroupId(), project.getArtifactId());
-    String oldVerion = coordinatesByPhase.get(ReleasePhase.PRE_RELEASE).getVersion();
+    String oldVersion = coordinatesByPhase.get(ReleasePhase.PRE_RELEASE).getVersion();
     String newVersion = coordinatesByPhase.get(ReleasePhase.RELEASE).getVersion();
     this.log.debug("\tUpdate of module version '" + project.getGroupId() + ":" + project.getArtifact() + "' ["
-        + oldVerion + " => " + newVersion + "]");
+        + oldVersion + " => " + newVersion + "]");
     PomUtil.setProjectVersion(project.getModel(), document, newVersion);
   }
 

--- a/plugin/src/main/java/com/itemis/maven/plugins/unleash/util/PomUtil.java
+++ b/plugin/src/main/java/com/itemis/maven/plugins/unleash/util/PomUtil.java
@@ -7,6 +7,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -14,7 +16,13 @@ import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
 
+import com.google.common.base.Joiner;
+import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Parent;
 import org.apache.maven.project.MavenProject;
@@ -63,6 +71,9 @@ public final class PomUtil {
   public static final String NODE_NAME_SCM_TAG = "tag";
   public static final String NODE_NAME_SCM_URL = "url";
   public static final String NODE_NAME_VERSION = "version";
+  public static final String NODE_NAME_DEPENDENCY = "dependency";
+  public static final String NODE_NAME_DEPENDENCIES = "dependencies";
+  public static final String NODE_NAME_DEPENDENCY_MANAGEMENT = "dependencyManagement";
 
   private PomUtil() {
     // Should not be instanciated
@@ -196,7 +207,7 @@ public final class PomUtil {
    *
    * @param model the POM where to adapt the project's parent version.
    * @param document the POM as an XML document in which the project's parent version shall be adapted.
-   * @param newVersion the new version to set for the project parent.
+   * @param newParentVersion the new version to set for the project parent.
    */
   public static void setParentVersion(Model model, Document document, String newParentVersion) {
     Preconditions.checkArgument(hasChildNode(document, NODE_NAME_PROJECT),
@@ -216,6 +227,61 @@ public final class PomUtil {
         Node child = children.item(i);
         if (Objects.equal(child.getNodeName(), PomUtil.NODE_NAME_VERSION)) {
           child.setTextContent(newParentVersion);
+        }
+      }
+    }
+  }
+
+  /**
+   * Changes the reactor dependency version of the POM as well as directly in the XML document preserving the whole
+   * document formatting.
+   *
+   * @param dependency the reactor dependency where to adapt the project version.
+   * @param document the POM as an XML document in which the project version shall be adapted.
+   * @param dependenciesPath the XPath to the {@code dependencies} starting from {@code /project/}.
+   *                         e.g. {@code /profiles/profile[id[text()='release']]/dependencyManagement}.
+   * @param newVersion the new dependency version to set.
+   */
+  public static void setDependencyVersion(Dependency dependency, Document document, String dependenciesPath,
+                                          String newVersion) {
+    Preconditions.checkArgument(hasChildNode(document, NODE_NAME_PROJECT),
+            "The document doesn't seem to be a POM model, project element is missing.");
+
+    // first step: update dependency version of the in-memory model
+    dependency.setVersion(newVersion);
+
+    // second step: update the dependency version in the DOM document that is then serialized for later building
+    NodeList dependencyNodes;
+    try {
+      List<String> xPathParts = new ArrayList<>();
+      xPathParts.add(NODE_NAME_PROJECT);
+      if (dependenciesPath.startsWith("/")) {
+        dependenciesPath = dependenciesPath.substring("/".length());
+      }
+      if (!dependenciesPath.isEmpty()) {
+        xPathParts.add(dependenciesPath);
+      }
+      xPathParts.add(NODE_NAME_DEPENDENCIES);
+      xPathParts.add(NODE_NAME_DEPENDENCY + "[groupId[text()='" + dependency.getGroupId() + "']"
+              + " and artifactId[text()='" + dependency.getArtifactId() + "']]");
+      String expression = "/" + Joiner.on("/").skipNulls().join(xPathParts);
+
+      XPath xPath = XPathFactory.newInstance().newXPath();
+      dependencyNodes = (NodeList) xPath.evaluate(expression,
+              document.getDocumentElement(), XPathConstants.NODESET);
+
+    } catch (XPathExpressionException e) {
+      String message = "Cannot evaluate xPath against '" + dependenciesPath + "'.";
+      throw new RuntimeException(message, e);
+    }
+
+    for (int i = 0; i < dependencyNodes.getLength(); i++) {
+      Node dependencyNode = dependencyNodes.item(i);
+      NodeList childNodes = dependencyNode.getChildNodes();
+      for (int j = 0; j < childNodes.getLength(); j++) {
+        Node childNode = childNodes.item(j);
+        if (Objects.equal(childNode.getNodeName(), PomUtil.NODE_NAME_VERSION)) {
+          childNode.setTextContent(newVersion);
         }
       }
     }

--- a/plugin/src/test/java/com/itemis/maven/plugins/unleash/util/PomUtilTest.java
+++ b/plugin/src/test/java/com/itemis/maven/plugins/unleash/util/PomUtilTest.java
@@ -10,8 +10,11 @@ import java.net.URL;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Parent;
+import org.apache.maven.model.Profile;
 import org.apache.maven.project.MavenProject;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -271,6 +274,86 @@ public class PomUtilTest {
 
     Assert.assertEquals(newVersion, getNode(document.getDocumentElement(), "parent/version").getTextContent());
     Assert.assertEquals(newVersion, model.getParent().getVersion());
+  }
+
+  @Test
+  public void testSetDependencyVersion() throws Exception {
+    URL url = getClass().getResource(getClass().getSimpleName() + "/pom5-reactor-dependencies.xml");
+    File source;
+    try {
+      source = new File(url.toURI());
+    } catch (URISyntaxException e) {
+      source = new File(url.getPath());
+    }
+
+    DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+    Document document = builder.parse(source);
+
+    Model model = new Model();
+    model.setGroupId("com.itemis.maven.plugins");
+    model.setArtifactId("test-project-1");
+    model.setVersion("1");
+
+    String oldDependencyVersion = "0.0.1-SNAPSHOT";
+    String newDependencyVersion = "0.0.1";
+
+    {
+      Dependency projectDependency = new Dependency();
+      projectDependency.setGroupId("com.cht.test");
+      projectDependency.setArtifactId("test-dep");
+      projectDependency.setVersion(oldDependencyVersion);
+      model.addDependency(projectDependency);
+      PomUtil.setDependencyVersion(projectDependency, document, "/", newDependencyVersion);
+      Assert.assertEquals(newDependencyVersion, getNode(document.getDocumentElement(), "dependencies/dependency/version").getTextContent());
+      Assert.assertEquals(oldDependencyVersion, getNode(document.getDocumentElement(), "dependencyManagement/dependencies/dependency/version").getTextContent());
+      Assert.assertEquals(oldDependencyVersion, getNode(document.getDocumentElement(), "profiles/profile/dependencies/dependency/version").getTextContent());
+      Assert.assertEquals(oldDependencyVersion, getNode(document.getDocumentElement(), "profiles/profile/dependencyManagement/dependencies/dependency/version").getTextContent());
+      Assert.assertEquals(newDependencyVersion, model.getDependencies().get(0).getVersion());
+    }
+
+    {
+      Dependency projectManagedDependency = new Dependency();
+      projectManagedDependency.setGroupId("com.cht.test");
+      projectManagedDependency.setArtifactId("test-dep");
+      projectManagedDependency.setVersion(oldDependencyVersion);
+      DependencyManagement projectDependencyManagement = new DependencyManagement();
+      projectDependencyManagement.addDependency(projectManagedDependency);
+      model.setDependencyManagement(projectDependencyManagement);
+      PomUtil.setDependencyVersion(projectManagedDependency, document, "/dependencyManagement", newDependencyVersion);
+      Assert.assertEquals(newDependencyVersion, getNode(document.getDocumentElement(), "dependencyManagement/dependencies/dependency/version").getTextContent());
+      Assert.assertEquals(oldDependencyVersion, getNode(document.getDocumentElement(), "profiles/profile/dependencies/dependency/version").getTextContent());
+      Assert.assertEquals(oldDependencyVersion, getNode(document.getDocumentElement(), "profiles/profile/dependencyManagement/dependencies/dependency/version").getTextContent());
+      Assert.assertEquals(newDependencyVersion, model.getDependencyManagement().getDependencies().get(0).getVersion());
+    }
+
+    Profile testProfile = new Profile();
+    testProfile.setId("test");
+    model.getProfiles().add(testProfile);
+
+    {
+      Dependency profileDependency = new Dependency();
+      profileDependency.setGroupId("com.cht.test");
+      profileDependency.setArtifactId("test-dep");
+      profileDependency.setVersion(oldDependencyVersion);
+      testProfile.getDependencies().add(profileDependency);
+      PomUtil.setDependencyVersion(profileDependency, document, "/profiles/profile[id[text()='test']]", newDependencyVersion);
+      Assert.assertEquals(newDependencyVersion, getNode(document.getDocumentElement(), "profiles/profile/dependencies/dependency/version").getTextContent());
+      Assert.assertEquals(oldDependencyVersion, getNode(document.getDocumentElement(), "profiles/profile/dependencyManagement/dependencies/dependency/version").getTextContent());
+      Assert.assertEquals(newDependencyVersion, model.getProfiles().get(0).getDependencies().get(0).getVersion());
+    }
+
+    {
+      Dependency profileManagedDependency = new Dependency();
+      profileManagedDependency.setGroupId("com.cht.test");
+      profileManagedDependency.setArtifactId("test-dep");
+      profileManagedDependency.setVersion(oldDependencyVersion);
+      DependencyManagement profileDependencyManagement = new DependencyManagement();
+      profileDependencyManagement.addDependency(profileManagedDependency);
+      testProfile.setDependencyManagement(profileDependencyManagement);
+      PomUtil.setDependencyVersion(profileManagedDependency, document, "/profiles/profile[id[text()='test']]/dependencyManagement", newDependencyVersion);
+      Assert.assertEquals(newDependencyVersion, getNode(document.getDocumentElement(), "profiles/profile/dependencyManagement/dependencies/dependency/version").getTextContent());
+      Assert.assertEquals(newDependencyVersion, model.getProfiles().get(0).getDependencies().get(0).getVersion());
+    }
   }
 
   @Test

--- a/plugin/src/test/resources/com/itemis/maven/plugins/unleash/util/PomUtilTest/pom5-reactor-dependencies.xml
+++ b/plugin/src/test/resources/com/itemis/maven/plugins/unleash/util/PomUtilTest/pom5-reactor-dependencies.xml
@@ -1,0 +1,51 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.itemis.maven.plugins</groupId>
+  <artifactId>test-project-1</artifactId>
+  <packaging>pom</packaging>
+
+  <name>Test Project 1</name>
+  <description>This is just a test POM for automated unit tests.</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.cht.test</groupId>
+      <artifactId>test-dep</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.cht.test</groupId>
+        <artifactId>test-dep</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <profiles>
+    <profile>
+      <id>test</id>
+      <dependencies>
+        <dependency>
+          <groupId>com.cht.test</groupId>
+          <artifactId>test-dep</artifactId>
+          <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+      </dependencies>
+
+      <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>com.cht.test</groupId>
+            <artifactId>test-dep</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+    </profile>
+  </profiles>
+</project>


### PR DESCRIPTION
Add the capability to set version of dependencies if they were in the reactor build:

1. Added `updateReactorDependencyVersion` configuration property and default to `true`.
2. When `updateReactorDependencyVersion == true`, `perform` goal will update the version of dependencies from reactor build in addition to the set project version and set parent version action.
3. Dependency version update take effects in both *direct dependencies* and *managed dependencies* in all profiles.
4. Only dependencies with the exact version string will be set. Meaning that version using expression will no be set in any case.

Future works:
1. `tychoPerform` remains unchanged since I am not familiar at it.
2. Only tested on my project failed to release using 2.6.0, related to #11.
3. For easier access to the *raw model*, I included the `versions-maven-plugin`. Perhaps the entire plugin should work on raw models only since they are closer to actual POMs. However, I have no confidence to do it without #11.
4. Dependency version property resolving & updating like [versions:update-properties](http://www.mojohaus.org/versions-maven-plugin/update-properties-mojo.html) ?