### PR TITLE
Add default property indicating that the unleash plugin is triggering the build

### DIFF
--- a/plugin/src/main/java/com/itemis/maven/plugins/unleash/steps/actions/BuildProject.java
+++ b/plugin/src/main/java/com/itemis/maven/plugins/unleash/steps/actions/BuildProject.java
@@ -104,6 +104,8 @@ public class BuildProject implements CDIMojoProcessingStep {
     // installation and deployment are performed in a later step. We first need to ensure that there are no changes in
     // the scm, ...
     request.setGoals(this.goals);
+    // Add default property indicating that the unleash plugin is triggering the build
+    this.releaseArgs.setProperty("unleash.build", "true");
     request.setProperties(this.releaseArgs);
     request.setProfiles(this.profiles);
     request.setShellEnvironmentInherited(true);


### PR DESCRIPTION
On some projects, we use profiles that are activated during the unleash release build. It would make the CLI usage a little bit more convenient if a default property is already predefined indicating that the build was triggered by the unleash plugin. This would make it possible to activate profiles based on the fact if the build is triggered by the unleash plugin, without always having to set this property explicitly via CLI.