### PR TITLE
refacto of pom.xml deps + update versions

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -17,167 +17,104 @@
     <maven>${version.maven}</maven>
   </prerequisites>
 
-  <properties>
-    <version.aether>1.0.2.v20150114</version.aether>
-    <version.artifact-spy-plugin>1.0.6</version.artifact-spy-plugin>
-    <version.cdi-api>1.2</version.cdi-api>
-    <version.cdi-plugin-utils>3.4.0</version.cdi-plugin-utils>
-    <version.commons-lang3>3.4</version.commons-lang3>
-    <version.guava>23.0</version.guava>
-    <version.junit>4.12</version.junit>
-    <version.junit-dataprovider>1.10.3</version.junit-dataprovider>
-    <version.maven>3.3.9</version.maven>
-    <version.maven-invoker>2.2</version.maven-invoker>
-    <version.maven-plugin-plugin>3.4</version.maven-plugin-plugin>
-    <version.mockito-all>1.10.19</version.mockito-all>
-    <version.plexus-interactivity-api>1.0-alpha-6</version.plexus-interactivity-api>
-    <version.tycho-versions-plugin>1.1.0</version.tycho-versions-plugin>
-    <version.versions-maven-plugin>2.5</version.versions-maven-plugin>
-    <version.weld-se>2.3.3.Final</version.weld-se>
-  </properties>
-
   <dependencies>
+    <!-- env -->
+    <!-- thoses two are declared Unused by dependency plugin-->
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-api</artifactId>
-      <version>${version.aether}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-connector-basic</artifactId>
-      <version>${version.aether}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-impl</artifactId>
-      <version>${version.aether}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-spi</artifactId>
-      <version>${version.aether}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-transport-file</artifactId>
-      <version>${version.aether}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-transport-http</artifactId>
-      <version>${version.aether}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-util</artifactId>
-      <version>${version.aether}</version>
+      <groupId>org.eclipse.tycho</groupId>
+      <artifactId>tycho-versions-plugin</artifactId>
+      <type>maven-plugin</type>
     </dependency>
     <dependency>
       <!-- just to be sure that the spy plugin is available in the aether -->
       <groupId>com.itemis.maven.plugins</groupId>
       <artifactId>artifact-spy-plugin</artifactId>
-      <version>${version.artifact-spy-plugin}</version>
       <type>maven-plugin</type>
       <scope>runtime</scope>
+    </dependency>
+
+    <!-- deps-->
+    <dependency>
+      <groupId>org.eclipse.aether</groupId>
+      <artifactId>aether-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.aether</groupId>
+      <artifactId>aether-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.enterprise</groupId>
       <artifactId>cdi-api</artifactId>
-      <version>${version.cdi-api}</version>
     </dependency>
     <dependency>
       <groupId>com.itemis.maven.plugins</groupId>
       <artifactId>cdi-plugin-utils</artifactId>
-      <version>${version.cdi-plugin-utils}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>${version.commons-lang3}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${version.guava}</version>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${version.junit}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.tngtech.java</groupId>
       <artifactId>junit-dataprovider</artifactId>
-      <version>${version.junit-dataprovider}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-aether-provider</artifactId>
-      <version>${version.maven}</version>
+      <artifactId>maven-model</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-settings</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
-      <version>${version.maven}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
-      <version>${version.maven}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-invoker</artifactId>
-      <version>${version.maven-invoker}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>${version.maven-plugin-plugin}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>${version.maven}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>${version.mockito-all}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-interactivity-api</artifactId>
-      <version>${version.plexus-interactivity-api}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.tycho</groupId>
-      <artifactId>tycho-versions-plugin</artifactId>
-      <version>${version.tycho-versions-plugin}</version>
-      <type>maven-plugin</type>
     </dependency>
     <dependency>
       <groupId>com.itemis.maven.plugins</groupId>
       <artifactId>unleash-scm-provider-api</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.itemis.maven.plugins</groupId>
       <artifactId>unleash-utils</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
       <artifactId>weld-se</artifactId>
-      <version>${version.weld-se}</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.mojo</groupId>
       <artifactId>versions-maven-plugin</artifactId>
-      <version>${version.versions-maven-plugin}</version>
+    </dependency>
+
+    <!-- TEST -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
     </dependency>
   </dependencies>
 

--- a/plugin/src/main/java/com/itemis/maven/plugins/unleash/util/ReleaseUtil.java
+++ b/plugin/src/main/java/com/itemis/maven/plugins/unleash/util/ReleaseUtil.java
@@ -2,15 +2,14 @@ package com.itemis.maven.plugins.unleash.util;
 
 import java.io.File;
 
+import com.google.common.base.Objects;
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
 import org.apache.maven.plugin.PluginParameterExpressionEvaluator;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
 import org.codehaus.plexus.components.interactivity.Prompter;
 import org.codehaus.plexus.components.interactivity.PrompterException;
-
-import com.google.common.base.Objects;
-import com.google.common.base.Optional;
-import com.google.common.base.Preconditions;
 
 /**
  * Provides some utility methods that are necessary to prepare the release process, such as version or tag name
@@ -19,6 +18,7 @@ import com.google.common.base.Preconditions;
  * @author <a href="mailto:stanley.hillner@itemis.de">Stanley Hillner</a>
  * @since 1.0.0
  */
+@SuppressWarnings("ALL")
 public final class ReleaseUtil {
 
   /**
@@ -128,10 +128,10 @@ public final class ReleaseUtil {
    * @param userDefined an optional user-defined path to use as maven home.
    * @return a path to a maven installation or {@code null} if none could be determined.
    */
-  public static File getMavenHome(Optional<String> userDefined) {
+  public static File getMavenHome(java.util.Optional<String> userDefined) {
     String path = null;
-    if (isValidMavenHome(userDefined.orNull())) {
-      path = userDefined.orNull();
+    if (isValidMavenHome(userDefined.orElse(null))) {
+      path = userDefined.orElse(null);
     } else {
       String sysProp = System.getProperty("maven.home");
       if (isValidMavenHome(sysProp)) {

--- a/plugin/src/test/java/com/itemis/maven/plugins/unleash/util/predicates/IsSnapshotDependencyTest.java
+++ b/plugin/src/test/java/com/itemis/maven/plugins/unleash/util/predicates/IsSnapshotDependencyTest.java
@@ -2,20 +2,33 @@ package com.itemis.maven.plugins.unleash.util.predicates;
 
 import org.apache.maven.model.Dependency;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
 
 import com.itemis.maven.plugins.unleash.util.PomPropertyResolver;
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
 
-@RunWith(DataProviderRunner.class)
+@RunWith(Parameterized.class)
 public class IsSnapshotDependencyTest {
-  @DataProvider
+
+  private static PomPropertyResolver propertyResolver;
+
+  private static IsSnapshotDependency predicate;
+
+  private final Dependency p;
+
+  private final boolean expected;
+
+  public IsSnapshotDependencyTest(Dependency p, boolean expected) {
+    this.p = p;
+    this.expected = expected;
+  }
+
+  @Parameterized.Parameters
   public static Object[][] dependencies() {
+    propertyResolver = Mockito.mock(PomPropertyResolver.class);
+    predicate = new IsSnapshotDependency(propertyResolver);
     return new Object[][] { { createDependencyAndInitPropertyResolver("1-SNAPSHOT", "1-SNAPSHOT"), true },
         { createDependencyAndInitPropertyResolver("1", "1"), false },
         { createDependencyAndInitPropertyResolver("1-snapshot", "1-snapshot"), true },
@@ -26,26 +39,16 @@ public class IsSnapshotDependencyTest {
         { createDependencyAndInitPropertyResolver(null, null), false } };
   }
 
-  private static PomPropertyResolver propertyResolver;
-  private static IsSnapshotDependency predicate;
-
-  @BeforeClass
-  public static void init() {
-    propertyResolver = Mockito.mock(PomPropertyResolver.class);
-    predicate = new IsSnapshotDependency(propertyResolver);
-  }
-
-  @Test
-  @UseDataProvider("dependencies")
-  public void TestApply(Dependency p, boolean expected) {
-    Assert.assertEquals(expected, predicate.apply(p));
-  }
-
   private static Dependency createDependencyAndInitPropertyResolver(String version, String resolverOutput) {
     Mockito.when(propertyResolver.expandPropertyReferences(version)).thenReturn(resolverOutput);
 
     Dependency d = new Dependency();
     d.setVersion(version);
     return d;
+  }
+
+  @Test
+  public void TestApply() {
+    Assert.assertEquals(expected, predicate.apply(p));
   }
 }

--- a/plugin/src/test/java/com/itemis/maven/plugins/unleash/util/predicates/IsSnapshotPluginTest.java
+++ b/plugin/src/test/java/com/itemis/maven/plugins/unleash/util/predicates/IsSnapshotPluginTest.java
@@ -2,20 +2,33 @@ package com.itemis.maven.plugins.unleash.util.predicates;
 
 import org.apache.maven.model.Plugin;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
 
 import com.itemis.maven.plugins.unleash.util.PomPropertyResolver;
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
 
-@RunWith(DataProviderRunner.class)
+@RunWith(Parameterized.class)
 public class IsSnapshotPluginTest {
-  @DataProvider
+
+  private static PomPropertyResolver propertyResolver;
+
+  private static IsSnapshotPlugin predicate;
+
+  private final Plugin p;
+
+  private final boolean expected;
+
+  public IsSnapshotPluginTest(Plugin p, boolean expected) {
+    this.p = p;
+    this.expected = expected;
+  }
+
+  @Parameterized.Parameters
   public static Object[][] plugins() {
+    propertyResolver = Mockito.mock(PomPropertyResolver.class);
+    predicate = new IsSnapshotPlugin(propertyResolver);
     return new Object[][] { { createPluginAndInitPropertyResolver("1-SNAPSHOT", "1-SNAPSHOT"), true },
         { createPluginAndInitPropertyResolver("1", "1"), false },
         { createPluginAndInitPropertyResolver("1-snapshot", "1-snapshot"), true },
@@ -26,26 +39,16 @@ public class IsSnapshotPluginTest {
         { createPluginAndInitPropertyResolver(null, null), false } };
   }
 
-  private static PomPropertyResolver propertyResolver;
-  private static IsSnapshotPlugin predicate;
-
-  @BeforeClass
-  public static void init() {
-    propertyResolver = Mockito.mock(PomPropertyResolver.class);
-    predicate = new IsSnapshotPlugin(propertyResolver);
-  }
-
-  @Test
-  @UseDataProvider("plugins")
-  public void TestApply(Plugin p, boolean expected) {
-    Assert.assertEquals(expected, predicate.apply(p));
-  }
-
   private static Plugin createPluginAndInitPropertyResolver(String version, String resolverOutput) {
     Mockito.when(propertyResolver.expandPropertyReferences(version)).thenReturn(resolverOutput);
 
     Plugin p = new Plugin();
     p.setVersion(version);
     return p;
+  }
+
+  @Test
+  public void TestApply() {
+    Assert.assertEquals(expected, predicate.apply(p));
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,186 @@
 
   <properties>
     <version.java>1.8</version.java>
+    <version.guava>27.0-jre</version.guava>
+    <version.junit>4.12</version.junit>
+    <version.junit-dataprovider>1.13.1</version.junit-dataprovider>
+    <version.aether>1.1.0</version.aether>
+    <version.artifact-spy-plugin>1.0.6</version.artifact-spy-plugin>
+    <version.cdi-api>2.0.SP1</version.cdi-api>
+    <version.cdi-plugin-utils>3.4.0</version.cdi-plugin-utils>
+    <version.commons-lang3>3.8.1</version.commons-lang3>
+    <version.maven>3.5.4</version.maven>
+    <version.maven-aether-provider>3.3.9</version.maven-aether-provider>
+    <version.maven-invoker>3.0.1</version.maven-invoker>
+    <version.maven-plugin-plugin>3.5.2</version.maven-plugin-plugin>
+    <version.versions-maven-plugin>2.7</version.versions-maven-plugin>
+    <version.mockito-all>1.10.19</version.mockito-all>
+    <version.plexus-interactivity-api>1.0-alpha-6</version.plexus-interactivity-api>
+    <version.tycho-versions-plugin>1.1.0</version.tycho-versions-plugin>
+    <version.weld-se>2.3.3.Final</version.weld-se>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- ENV -->
+      <dependency>
+        <!-- just to be sure that the spy plugin is available in the aether -->
+        <groupId>com.itemis.maven.plugins</groupId>
+        <artifactId>artifact-spy-plugin</artifactId>
+        <version>${version.artifact-spy-plugin}</version>
+        <type>maven-plugin</type>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-versions-plugin</artifactId>
+        <version>${version.tycho-versions-plugin}</version>
+        <type>maven-plugin</type>
+      </dependency>
+
+      <!-- DEPS -->
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>${version.guava}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.enterprise</groupId>
+        <artifactId>cdi-api</artifactId>
+        <version>${version.cdi-api}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>${version.commons-lang3}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.aether</groupId>
+        <artifactId>aether-api</artifactId>
+        <version>${version.aether}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.aether</groupId>
+        <artifactId>aether-connector-basic</artifactId>
+        <version>${version.aether}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.aether</groupId>
+        <artifactId>aether-impl</artifactId>
+        <version>${version.aether}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.aether</groupId>
+        <artifactId>aether-spi</artifactId>
+        <version>${version.aether}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.aether</groupId>
+        <artifactId>aether-transport-file</artifactId>
+        <version>${version.aether}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.aether</groupId>
+        <artifactId>aether-transport-http</artifactId>
+        <version>${version.aether}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.aether</groupId>
+        <artifactId>aether-util</artifactId>
+        <version>${version.aether}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.itemis.maven.plugins</groupId>
+        <artifactId>cdi-plugin-utils</artifactId>
+        <version>${version.cdi-plugin-utils}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-aether-provider</artifactId>
+        <version>${version.maven-aether-provider}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-model</artifactId>
+        <version>${version.maven}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-settings</artifactId>
+        <version>${version.maven}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-artifact</artifactId>
+        <version>${version.maven}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-core</artifactId>
+        <version>${version.maven}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-plugin-api</artifactId>
+        <version>${version.maven}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.shared</groupId>
+        <artifactId>maven-invoker</artifactId>
+        <version>${version.maven-invoker}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.plugin-tools</groupId>
+        <artifactId>maven-plugin-annotations</artifactId>
+        <version>${version.maven-plugin-plugin}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-interactivity-api</artifactId>
+        <version>${version.plexus-interactivity-api}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.itemis.maven.plugins</groupId>
+        <artifactId>unleash-scm-provider-api</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.itemis.maven.plugins</groupId>
+        <artifactId>unleash-utils</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.weld.se</groupId>
+        <artifactId>weld-se</artifactId>
+        <version>${version.weld-se}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
+        <version>${version.versions-maven-plugin}</version>
+      </dependency>
+
+      <!-- TEST DEPS -->
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-all</artifactId>
+        <version>${version.mockito-all}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>${version.junit}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.tngtech.java</groupId>
+        <artifactId>junit-dataprovider</artifactId>
+        <version>${version.junit-dataprovider}</version>
+        <scope>test</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <build>
     <pluginManagement>
@@ -76,7 +255,7 @@
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-javadoc-plugin</artifactId>
               <configuration>
-                <additionalparam>-Xdoclint:none</additionalparam>
+                <doclint>none</doclint>
               </configuration>
             </plugin>
           </plugins>

--- a/scm-provider-api/pom.xml
+++ b/scm-provider-api/pom.xml
@@ -11,27 +11,18 @@
   <name>Unleash SCM Provider API</name>
   <description>The API used by the Unleash Maven Plugin to talk to different SCM providers.</description>
 
-  <properties>
-    <version.cdi-api>1.2</version.cdi-api>
-    <version.commons-lang3>3.4</version.commons-lang3>
-    <version.guava>23.0</version.guava>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>javax.enterprise</groupId>
       <artifactId>cdi-api</artifactId>
-      <version>${version.cdi-api}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>${version.commons-lang3}</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>${version.guava}</version>
     </dependency>
   </dependencies>
 </project>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -11,28 +11,19 @@
   <name>Unleash Utilities</name>
   <description>Common utility classes provided and used by the plugin. These utilities can f.i. be used by external tools, such as CI server integration plugins.</description>
 
-  <properties>
-    <version.guava>23.0</version.guava>
-    <version.junit>4.12</version.junit>
-    <version.junit-dataprovider>1.10.3</version.junit-dataprovider>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>${version.guava}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.tngtech.java</groupId>
       <artifactId>junit-dataprovider</artifactId>
-      <version>${version.junit-dataprovider}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This PR is refactoring the pom to pack all dependency management in the parent pom and declare them in children.
It also update dependency version to latest as much as possible based on `versions:use-latest-releases` output.
It then prune some dependencies based on `mvn dependency:analyze` but without removing :
* org.eclipse.tycho:tycho-versions-plugin:maven-plugin:1.1.0:compile
* com.itemis.maven.plugins:artifact-spy-plugin:maven-plugin:1.0.6:runtime

Tests were edited because junit upgrade made them fail. They were updated to use the junit integrated parameterized tests feature.